### PR TITLE
Change method to get account ID and way the S3 bucket is created

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,9 +12,9 @@ if ! command -v aws > /dev/null; then
     exit 1
 fi
 
-ACCOUNT_ID=`aws iam get-user | grep 'arn:aws:iam' | tr -dc '0-9'`
-BUCKET_NAME="${ACCOUNT_ID}-startup-kit-serverless-todo-app"
+ACCOUNT_ID=`aws sts get-caller-identity --query 'Account' --output=text`
 REGION=`aws configure get region`
+BUCKET_NAME="${ACCOUNT_ID}-${REGION}-startup-kit-serverless-todo-app"
 
 # Check if the account id is valid
 if ! [[ ${ACCOUNT_ID} =~ ${DIGITS_RE} ]] ; then


### PR DESCRIPTION
The way we get the AWS Account ID forces this to be performed by an IAM user, the better option is to move to STS's `get-caller-identity` API instead. This allows the operator of the install script to use roles if required.

The way we generate buckets should be regional, rather than global.

Any questions, ping me on chime as: thulsimo@