### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/serverless.cfn.yml
+++ b/serverless.cfn.yml
@@ -20,7 +20,7 @@ Description: Startup Kit RESTful API backed by a SimpleTable (DynamoDB).
 Globals:
 
   Function:
-    Runtime: nodejs8.10
+    Runtime: nodejs10.x
     Environment:
       Variables:
         TABLE_NAME: !Ref Table


### PR DESCRIPTION
CloudFormation templates in startup-kit-serverless-workload have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.