### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/serverless.cfn.yml
+++ b/serverless.cfn.yml
@@ -20,7 +20,7 @@ Description: Startup Kit RESTful API backed by a SimpleTable (DynamoDB).
 Globals:
 
   Function:
-    Runtime: nodejs10.x
+    Runtime: nodejs14.x
     Environment:
       Variables:
         TABLE_NAME: !Ref Table


### PR DESCRIPTION
CloudFormation templates in startup-kit-serverless-workload have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.